### PR TITLE
Bugfix drag and drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.2] - 2025-03-02
+
+### Fixed
+- Fix `ValueError` when dragging and dropping a `FigureWidget` shape.
+
 ## [6.0.1] - 2025-02-16
 
 ### Fixed

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4682,6 +4682,7 @@ class BasePlotlyType(object):
             CompoundArrayValidator,
             BaseDataValidator,
         )
+        from .validators.layout._shapes import ShapesValidator
 
         # Normalize prop
         # --------------
@@ -4707,7 +4708,6 @@ class BasePlotlyType(object):
                 )
 
             validator = self._get_validator(prop)
-
             if isinstance(validator, CompoundValidator):
                 if self._compound_props.get(prop, None) is None:
                     # Init compound objects
@@ -4719,6 +4719,12 @@ class BasePlotlyType(object):
                     self._compound_props[prop]._plotly_name = prop
 
                 return validator.present(self._compound_props[prop])
+            elif isinstance(validator, ShapesValidator):
+                props = []
+                if self._props is not None and prop in self._props:
+                    props = [validator.data_class() for _ in self._props.get(prop, [])]
+
+                return validator.present(props)
             elif isinstance(validator, (CompoundArrayValidator, BaseDataValidator)):
                 if self._compound_array_props.get(prop, None) is None:
                     # Init list of compound objects


### PR DESCRIPTION
## Code PR

This PR fixes #4374. The problem is that the Layout is initialized with no shapes and the drag and drop would trigger a relayout_data with shapes that weren't available. This PR 

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] ~~For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).~~
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] ~~For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).~~

I actually tried to reproduce the error by writing a test programatically, but it didn't work. I wasn't able to find a way to reproduce the js events in the python code and relying on the relayout event wasn't enough to reproduce it. 

```python
def test_plotly_relayout_drag_and_drop_polygons() -> None:
    """
    Validate that the plotly_relayout method can handle drag and drop.
    """

    fig = go.FigureWidget(
        layout=go.Layout(
            showlegend=False,
            autosize=True,
            dragmode="drawrect",
            modebar={
                "add": [
                    "drawclosedpath",
                    "drawcircle",
                    "drawrect",
                    "eraseshape",
                ]
            },
        )
    )
    fig.add_shape(
        type="rect",
        x0=-0.06666666666666662,
        y0=2.4908854166666665,
        x1=2.1500000000000004,
        y1=0.3519965277777778,
    )

    new_shape = {
        "x0": -0.07964149504195264,
        "x1": 3.692616323417239,
        "y0": 3.1297222222222225,
        "y1": 1.213055555555555,
    }

    drag_and_drop_relayout_data = {
        f'shapes[0].{pos}': value for pos, value in new_shape.items()
    }

    fig.plotly_relayout(
        relayout_data=drag_and_drop_relayout_data
    )

    for pos, value in new_shape.items():
        assert fig.layout.shapes[0][pos] == value
```


